### PR TITLE
Fix compatibility with latest python

### DIFF
--- a/django_remote_forms/fields.py
+++ b/django_remote_forms/fields.py
@@ -40,7 +40,7 @@ class RemoteField(object):
         try:
             remote_widget_class = getattr(widgets, remote_widget_class_name)
             remote_widget = remote_widget_class(self.field.widget, field_name=self.field_name)
-        except Exception, e:
+        except Exception as e:
             logger.warning('Error serializing %s: %s', remote_widget_class_name, str(e))
             widget_dict = {}
         else:

--- a/django_remote_forms/forms.py
+++ b/django_remote_forms/forms.py
@@ -138,7 +138,7 @@ class RemoteForm(object):
             try:
                 remote_field_class = getattr(fields, remote_field_class_name)
                 remote_field = remote_field_class(field, form_initial_field_data, field_name=name)
-            except Exception, e:
+            except Exception as e:
                 logger.warning('Error serializing field %s: %s', remote_field_class_name, str(e))
                 field_dict = {}
             else:

--- a/django_remote_forms/utils.py
+++ b/django_remote_forms/utils.py
@@ -1,5 +1,5 @@
 from django.utils.functional import Promise
-from django.utils.encoding import force_unicode
+from django.utils.encoding import force_str
 
 
 def resolve_promise(o):
@@ -10,7 +10,7 @@ def resolve_promise(o):
         o = [resolve_promise(x) for x in o]
     elif isinstance(o, Promise):
         try:
-            o = force_unicode(o)
+            o = force_str(o)
         except:
             # Item could be a lazy tuple or list
             try:


### PR DESCRIPTION
Fixed `SyntaxError: invalid syntax` error: `except Exception, e:` > `except Exception as e:`